### PR TITLE
refactor and simplify code

### DIFF
--- a/addon/components/tui-editor.js
+++ b/addon/components/tui-editor.js
@@ -79,7 +79,7 @@ export default Component.extend({
           // `value` is a special case because using `setValue`
           // moves the current cursor position so we need to avoid calling it
           // only call it when the editor value is different from the new value we got
-          if (optionName === 'value') {
+          if (optionName === 'value' && this.editor.getValue) {
             let editorValue = this.editor.getValue();
             if (editorValue !== value) {
               this.editor.setValue(value);

--- a/addon/components/tui-editor.js
+++ b/addon/components/tui-editor.js
@@ -1,157 +1,108 @@
 import Component from '@ember/component';
-import { observer } from '@ember/object';
+import { computed } from '@ember/object';
+import { assert } from '@ember/debug';
+import { assign } from '@ember/polyfills';
+
 import layout from '../templates/components/tui-editor';
 import Editor from 'tui-editor';
 
-
 export default Component.extend({
-    layout,
+  layout,
 
-    height: '300px',
-    minHeight: '200px',
-    value: '',
-    previewStyle: 'tab',
-    editType: 'markdown',
-    language: 'en_US',
-    useCommandShortcut: true,
-    useDefaultHTMLSanitizer: true,
-    //codeBlockLanguages: null,
-    usageStatistics: false,
-    toolbarItems: Object.freeze([
-        'heading',
-        'bold',
-        'italic',
-        'strike',
-        'divider',
-        'hr',
-        'quote',
-        'divider',
-        'ul',
-        'ol',
-        'task',
-        'indent',
-        'outdent',
-        'divider',
-        'table',
-        'image',
-        'link',
-        'divider',
-        'code',
-        'codeblock'
-    ]),
-    hideModeSwitch: false,
-    viewer: false,
+  value: '',
 
-    /*importStyle: task(function *() {
-        yield all([
-            import('codemirror/lib/codemirror.css'),
-            import('tui-editor/dist/tui-editor.css'),
-            import('tui-editor/dist/tui-editor-contents.css'),
-            import('highlight.js/styles/github.css')
-        ]);
-    }).on('init'),*/
+  // here we use a syntax like <property>:<method>:<tui option> to update such property (optional)>
+  tuiOptions: Object.freeze([
+    'previewStyle:changePreviewStyle', 'editType:changeMode:initialEditType', 'height:height', 'minHeight:minHeight',
+    'language', 'useDefaultHTMLSanitizer', 'useCommandShortcut', 'codeBlockLanguages', 'usageStatistics',
+    'toolbarItems', 'hideModeSwitch', 'viewer', 'value:setValue:initialValue'
+  ]),
 
-    didInsertElement() {
-        this._super(...arguments);
+  // gathers all the options to initialize TUI editor, respecting tuiOptions syntax
+  options: computed('tuiOptions.[]', function() {
+    let options = {};
 
-        this.setupEditor();
-    },
+    this.get('tuiOptions').forEach((o) => {
+      let [optionName, ,tuiOption] = o.split(':');
+      tuiOption = tuiOption ? tuiOption : optionName;
 
-    setupEditor() {
-        //let Editor = yield import('tui-editor');
+      options[tuiOption] = this.get(optionName);
+    });
 
-        let editor = Editor.factory({
-            viewer: this.viewer,
-            el: this.element,
-            height: this.height,
-            minHeight: this.minHeight,
-            initialValue: this.value,
-            previewStyle: this.previewStyle,
-            initialEditType: this.editType,
-            language: this.language,
-            useCommandShortcut: this.useCommandShortcut,
-            useDefaultHTMLSanitizer: this.useDefaultHTMLSanitizer,
-            //codeBlockLanguages: this.codeBlockLanguages,
-            usageStatistics: this.usageStatistics,
-            toolbarItems: this.toolbarItems,
-            hideModeSwitch: this.hideModeSwitch,
+    return options;
+  }),
 
-            events: {
-                load: () => this.onLoadWrapper(),
-                change: () => this.onChangeWrapper(),
-                stateChange: () => this.onStateChangeWrapper(),
-                focus: () => this.onFocusWrapper(),
-                blur: () => this.onBlurWrapper()
-            },
-        });
+  didInsertElement() {
+    this._super(...arguments);
+    this.setupEditor();
+    this.addObservers();
+  },
 
-        this.set('editor', editor);
-    },
+  willDestroyElement() {
+    this._super(...arguments);
+    this.removeObservers();
+  },
 
-    valueChanged: observer('value', function() {
-        if (this.editor.getValue && this.editor.getValue() === this.value) {
-            return;
-        }
+  setupEditor() {
+    let options = this.get('options');
 
-        this.editor.setValue(this.value);
-    }),
+    let editor = Editor.factory(assign(options, {
+      el: this.element,
+      events: {
+        load: (...args) => this.eventInvoked('onLoad', ...args),
+        change: (...args) => this.eventInvoked('onChange', this.editor.getValue(), ...args),
+        stateChange: (...args) => this.eventInvoked('onStateChange', ...args),
+        focus: (...args) => this.eventInvoked('onFocus', ...args),
+        blur: (...args) => this.eventInvoked('onBlur', ...args)
+      }
+    }));
 
-    heightChanged: observer('height', function() {
-        this.editor.height(this.height);
-    }),
+    this.set('editor', editor);
+  },
 
-    minHeightChanged: observer('minHeight', function() {
-        this.editor.minHeight(this.minHeight);
-    }),
-
-    previewStyleChanged: observer('previewStyle', function() {
-        this.editor.changePreviewStyle(this.previewStyle);
-    }),
-
-    editTypeChanged: observer('editType', function() {
-        this.editor.changeMode(this.editType);
-    }),
-
-    /*
-    TODO this is quite buggy
-    parameterChanged: observer(
-            'language',
-            'useCommandShortcut',
-            'useDefaultHTMLSanitizer',
-            'toolbarItems.[]',
-            'hideModeSwitch',
-            function() {
-        this.editor.remove();
-        this.setupEditor();
-    }),*/
-
-    onLoadWrapper() {
-        if (this.get('onLoad')) {
-            this.onLoad();
-        }
-    },
-
-    onChangeWrapper() {
-        if (this.get('onChange')) {
-            this.onChange(this.editor.getValue());
-        }
-    },
-
-    onStateChangeWrapper() {
-        if (this.get('onStateChange')) {
-            this.onStateChange();
-        }
-    },
-
-    onFocusWrapper() {
-        if (this.get('onFocus')) {
-            this.onFocus();
-        }
-    },
-
-    onBlurWrapper() {
-        if (this.get('onBlur')) {
-            this.onBlur();
-        }
+  // tests if an `actionName` function exists and calls it with the arguments if so
+  eventInvoked(actionName, ...args) {
+    if (this.get(actionName)) {
+      this.get(actionName)(...args);
     }
+  },
+
+  addObservers() {
+    this._observers = {};
+    this.get('tuiOptions').forEach((o) => {
+      let [optionName, tuiMethod] = o.split(':');
+
+      if (tuiMethod) {
+        this._observers[optionName] = function() {
+          let value = this.get(optionName);
+
+          // `value` is a special case because using `setValue`
+          // moves the current cursor position so we need to avoid calling it
+          // only call it when the editor value is different from the new value we got
+          if (optionName === 'value') {
+            let editorValue = this.editor.getValue();
+            if (editorValue !== value) {
+              this.editor.setValue(value);
+            }
+          } else {
+            assert(`Editor instance should be have a function '${tuiMethod}' but found ${this.editor[tuiMethod]} instead.`, !!this.editor[tuiMethod]);
+            this.editor[tuiMethod].call(this.editor, value);
+          }
+        };
+
+        this.addObserver(optionName, this, this._observers[optionName]);
+      }
+    });
+  },
+
+  removeObservers() {
+    if (this._observers) {
+      this.get('tuiOptions').forEach((o) => {
+        let [optionName] = o.split(':');
+
+        this.removeObserver(optionName, this, this._observers[optionName]);
+        delete this._observers[optionName];
+      });
+    }
+  }
 });

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -1,56 +1,54 @@
 <div class="main">
-    <h2 id="title"><a href="https://github.com/evocount/ember-tui-editor">Ember-tui-editor</a> Demo</h2>
+  <h2 id="title"><a href="https://github.com/evocount/ember-tui-editor">Ember-tui-editor</a> Demo</h2>
 
-    {{code-snippet name="tui-editor.hbs"}}
+  {{code-snippet name="tui-editor.hbs"}}
 
-    {{tui-editor
-        height=height
-        minHeight=minHeight
-        value=value
-        previewStyle=previewStyle
-        editType=editType
-        onChange=(action (mut value))
-    }}
+  {{tui-editor
+    height=height
+    minHeight=minHeight
+    previewStyle=previewStyle
+    editType=editType
+    value=value
+    onChange=(action (mut value))
+  }}
 
-    <form>
-        <div>
-            <label for="height">Height: </label>
-            {{input value=height id="height"}}
-        </div>
+  <form>
+    <div>
+      <label for="height">Height:</label>
+      {{input value=height id="height"}}
+    </div>
 
-        <div>
-            <label for="minHeight">Min Height: </label>
-            {{input value=minHeight id="minHeight"}}
-        </div>
+    <div>
+      <label for="minHeight">Min Height:</label>
+      {{input value=minHeight id="minHeight"}}
+    </div>
 
-        <div>
-            <label for="previewStyle">Preview style: </label>
-            {{#power-select
-                options=previewStyles
-                selected=previewStyle
-                onchange=(action (mut previewStyle))
-                searchEnabled=false as |item|}}
-                  {{item}}
-            {{/power-select}}
-        </div>
+    <div>
+      <label for="previewStyle">Preview style:</label>
+      {{#power-select
+        options=previewStyles
+        selected=previewStyle
+        onchange=(action (mut previewStyle))
+        searchEnabled=false as |item|}}
+        {{item}}
+      {{/power-select}}
+    </div>
 
-        <div>
-            <label for="editType">Edit type: </label>
-            {{#power-select
-                id="editType"
-                options=editTypes
-                selected=editType
-                onchange=(action (mut editType))
-                searchEnabled=false as |item|}}
-                  {{item}}
-            {{/power-select}}
-        </div>
+    <div>
+      <label for="editType">Edit type: </label>
+      {{#power-select
+        id="editType"
+        options=editTypes
+        selected=editType
+        onchange=(action (mut editType))
+        searchEnabled=false as |item|}}
+        {{item}}
+      {{/power-select}}
+    </div>
 
-        <div>
-            <label for="value">Value: </label>
-            {{textarea value=value rows="10" id="value"}}
-        </div>
-    </form>
-
-    {{!-- {{tui-editor value=value viewer=true}} --}}
+    <div>
+      <label for="value">Value: </label>
+      {{textarea value=value rows="10" id="value"}}
+    </div>
+  </form>
 </div>


### PR DESCRIPTION
Hi. 👋 

This is the first of a series of PRs that I intend to make. To make your review easier.

This one is basically a refactor of code.

The advantages are:
- we're no longer hardcoding the default options and instead let TUI decide that for us
- if users want, they can pass in `options=(hash ...` directly as an escape valve
- much easier to maintain, i.e if TUI adds a new options, we just need to add it to `tuiOptions` array
- much better readability
- code styling in line with community standards

This also fixes a bug where:
- if you were on WYSIWYG mode
- type something at the beginning of a paragraph
- the cursor would be moved to the end of the text because `setValue` was called

Now we're making sure that we only call `setValue` if the values are actually different.

Let me know if you need something for me here! 👍 