### PR TITLE
do not add undefined options

### DIFF
--- a/addon/components/tui-editor.js
+++ b/addon/components/tui-editor.js
@@ -25,8 +25,11 @@ export default Component.extend({
     this.get('tuiOptions').forEach((o) => {
       let [optionName, ,tuiOption] = o.split(':');
       tuiOption = tuiOption ? tuiOption : optionName;
+      let value = this.get(optionName);
 
-      options[tuiOption] = this.get(optionName);
+      if (value !== undefined) {
+        options[tuiOption] = value;
+      }
     });
 
     return options;


### PR DESCRIPTION
As it was, we were passing things like the following, when the options weren't passed in:

```js
{
  previewStyle: undefined,
  initialEditType: undefined,
  // ...
}
```

Better be safe and not include any undefined options when creating the editor. I don't think there's any problem with that at the moment, but it's better to be safe because we never know how TUI will check for option presence in the future.
