### PR TITLE
allow customization of editor element

### DIFF
--- a/addon/templates/components/tui-editor.hbs
+++ b/addon/templates/components/tui-editor.hbs
@@ -1,3 +1,3 @@
-<div {{did-insert this.setupEditor}} {{will-destroy this.destroyEditor}}>
+<div {{did-insert this.setupEditor}} {{will-destroy this.destroyEditor}} ...attributes>
   {{yield}}
 </div>


### PR DESCRIPTION
This is a simple change that allows us to customize the attributes of the editor div element. e.g `<TuiEditor class="my-editor" ...`.

Perhaps this could be released as a patch version?