### PR TITLE
Draft: Try using execCommand with insertText for integration testing

### DIFF
--- a/tests/integration/components/tui-editor-test.js
+++ b/tests/integration/components/tui-editor-test.js
@@ -1,0 +1,28 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { focus, render, waitFor } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Component | tui-editor', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('onChange event is fired when user enters text', async function (assert) {
+    assert.expect(2);
+
+    this.set('onChangeHandler', () => {});
+
+    await render(hbs`<TuiEditor @onChange={{this.onChangeHandler}} />`);
+    await waitFor('[contenteditable]');
+    await focus('[contenteditable]');
+
+    this.set('onChangeHandler', (text) => {
+      assert.ok('onChange handler is executed');
+      assert.equal(
+        text,
+        'foo',
+        'onChange handler handler receives text as first argument'
+      );
+    });
+    document.execCommand('insertText', false, 'foo');
+  });
+});


### PR DESCRIPTION
I struggle with writing integration and acceptance test for user flows, which require adding text in Toast UI Editor. See #477 for more context.

This PR shows an attempt to use `document.execCommand` in integration tests. It seems to work out so far. But triggers an error deep inside the code of Toast UI Editor:

```
index.es.js:484 Uncaught TypeError: Cannot read properties of null (reading 'nearestDesc')
    at posFromCaret (index.es.js:484:29)
    at posAtCoords (index.es.js:615:15)
    at EditorView.posAtCoords$1 [as posAtCoords] (index.es.js:6944:10)
    at ScrollSync.syncPreviewScrollTop (index.js:1025:505)
    at eval (index.js:1024:29)
```