### PR TITLE
Change initialization of Editor as Viewer works again

### DIFF
--- a/addon/components/tui-editor.js
+++ b/addon/components/tui-editor.js
@@ -69,7 +69,7 @@ export default class TuiEditor extends Component {
     await importLocale(this.language);
     const { Editor } = await import('@toast-ui/editor');
 
-    this.editor = new Editor(
+    this.editor = new Editor.factory(
       assign(this.options, {
         el: element,
         events: {


### PR DESCRIPTION
Hello

I noticed that on latest version of add-on, Viewer option just don't work. After digging documentation for TUI-Editor itself, I found that they change API slightly. As per that [page](https://github.com/nhn/tui.editor/blob/master/docs/en/viewer.md#another-way-to-create-viewer) now you need to instantiate editor from factory, so you not loading both Viewer and Editor, but without factory Viewer just don't work.

After that change both Viewer and Editor works fine.