### PR TITLE
Remove usage of `assign` polyfill

### DIFF
--- a/addon/components/tui-editor.js
+++ b/addon/components/tui-editor.js
@@ -1,6 +1,5 @@
 import { action } from '@ember/object';
 import { assert } from '@ember/debug';
-import { assign } from '@ember/polyfills';
 
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
@@ -70,7 +69,7 @@ export default class TuiEditor extends Component {
     const { Editor } = await import('@toast-ui/editor');
 
     this.editor = new Editor.factory(
-      assign(this.options, {
+      Object.assign(this.options, {
         el: element,
         events: {
           load: (...args) => this.eventInvoked('onLoad', ...args),


### PR DESCRIPTION
Starting with Ember v4.x the `Ember.assign` polyfill is deprecated : https://deprecations.emberjs.com/v4.x#toc_ember-polyfills-deprecate-assign

`Object.assign` has been implemented in every browsers for a long time now (see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/assign#browser_compatibility), so it seems reasonable to use it in place of the polyfill.

Thanks for your work.