### PR TITLE
Fix embroider compatibility

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ module.exports = {
 
   options: {
     babel: {
-      plugins: [require('ember-auto-import/babel-plugin')],
+      plugins: [require.resolve('ember-auto-import/babel-plugin')],
     },
   },
 


### PR DESCRIPTION
## Issue
embroider needs to disable `ember-auto-import`'s babel plugin when not necessary.

## Solution
Use `required.resolve` instead of `require` when adding the plugin to babel's configuration.

Thanks for your work!