### PR TITLE
Enable CI with GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,9 +59,8 @@ jobs:
         try-scenario:
           - ember-lts-3.16
           - ember-lts-3.28
-          # TODO: Ember > 4 requires a dependency on ember-auto-import@~2.
-          #       This is a breaking change and should be done in a follow-up.
-          # - ember-lts-4.12
+          - ember-lts-4.12
+          # TODO: Run tests with Ember v5
           # - ember-lts-5.4
           # - ember-release
           # - ember-beta

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,11 +61,15 @@ jobs:
         try-scenario:
           - ember-lts-3.16
           - ember-lts-3.28
-          - ember-lts-4.12
-          - ember-lts-5.4
-          - ember-release
+          # TODO: Ember > 4 requires a dependency on ember-auto-import@~2.
+          #       This is a breaking change and should be done in a follow-up.
+          # - ember-lts-4.12
+          # - ember-lts-5.4
+          # - ember-release
           # - ember-beta
           # - ember-canary
+          #
+          # TODO: Enable tests for Embroider.
           # - embroider-safe
           # - embroider-optimized
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - main
       - master
+      # TODO: REMOVE BEFORE MERGING
+      - fix-tests-and-enable-ci
   pull_request: {}
 
 concurrency:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,80 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+      - master
+  pull_request: {}
+
+concurrency:
+  group: ci-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: "Tests"
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          cache: npm
+      - name: Install Dependencies
+        run: npm ci
+      - name: Lint
+        run: npm run lint
+      - name: Run Tests
+        run: npm run test:ember
+
+  floating:
+    name: "Floating Dependencies"
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          cache: npm
+      - name: Install Dependencies
+        run: npm install --no-shrinkwrap
+      - name: Run Tests
+        run: npm run test:ember
+
+  try-scenarios:
+    name: ${{ matrix.try-scenario }}
+    runs-on: ubuntu-latest
+    needs: "test"
+    timeout-minutes: 10
+
+    strategy:
+      fail-fast: false
+      matrix:
+        try-scenario:
+          - ember-lts-3.16
+          - ember-lts-3.28
+          - ember-lts-4.12
+          - ember-lts-5.4
+          - ember-release
+          # - ember-beta
+          # - ember-canary
+          # - embroider-safe
+          # - embroider-optimized
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          cache: npm
+      - name: Install Dependencies
+        run: npm ci
+      - name: Run Tests
+        run: ./node_modules/.bin/ember try:one ${{ matrix.try-scenario }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,8 +5,6 @@ on:
     branches:
       - main
       - master
-      # TODO: REMOVE BEFORE MERGING
-      - fix-tests-and-enable-ci
   pull_request: {}
 
 concurrency:

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -26,7 +26,12 @@ module.exports = async function () {
       {
         name: 'ember-lts-4.12',
         npm: {
+          dependencies: {
+            'ember-auto-import': '^2.7.4',
+          },
           devDependencies: {
+            'ember-cli': '~3.28.0',
+            'ember-qunit': '^6.2.0',
             'ember-source': '~4.12.0',
           },
         },

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -14,10 +14,26 @@ module.exports = async function () {
         },
       },
       {
-        name: 'ember-lts-3.20',
+        name: 'ember-lts-3.28',
         npm: {
           devDependencies: {
-            'ember-source': '~3.20.5',
+            'ember-source': '~3.28.0',
+          },
+        },
+      },
+      {
+        name: 'ember-lts-4.12',
+        npm: {
+          devDependencies: {
+            'ember-source': '~4.12.0',
+          },
+        },
+      },
+      {
+        name: 'ember-lts-5.4',
+        npm: {
+          devDependencies: {
+            'ember-source': '~5.4.0',
           },
         },
       },

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -9,8 +9,9 @@ module.exports = async function () {
         name: 'ember-lts-3.16',
         npm: {
           devDependencies: {
-            'ember-source': '~3.16.0',
             'ember-in-element-polyfill': '^1.0.1',
+            'ember-maybe-in-element': '2.0.3',
+            'ember-source': '~3.16.0',
           },
         },
       },

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -10,6 +10,7 @@ module.exports = async function () {
         npm: {
           devDependencies: {
             'ember-source': '~3.16.0',
+            'ember-in-element-polyfill': '^1.0.1',
           },
         },
       },

--- a/package.json
+++ b/package.json
@@ -89,5 +89,8 @@
   "ember-addon": {
     "configPath": "tests/dummy/config",
     "demoURL": "https://evocount.github.io/ember-tui-editor/"
+  },
+  "volta": {
+    "node": "16.20.2"
   }
 }

--- a/tests/integration/components/tui-editor-test.js
+++ b/tests/integration/components/tui-editor-test.js
@@ -1,12 +1,11 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, settled, waitFor } from '@ember/test-helpers';
+import { render } from '@ember/test-helpers';
 import {
   fillInEditor,
   waitForEditor,
 } from 'ember-tui-editor/test-support/helpers';
 import { hbs } from 'ember-cli-htmlbars';
-import { set } from '@ember/object';
 
 module('Integration | Component | tui-editor', function (hooks) {
   setupRenderingTest(hooks);


### PR DESCRIPTION
Setting up CI for this project with GitHub Actions. Please see [this run](https://github.com/jelhan/ember-tui-editor/actions/runs/10679718456) in my fork as an example that it works.

So far the CI only tests compatibility with Ember 3.16, 3.28 and 4.12. Ember > 5 requires some additional work, which I have not done yet. I will do that in a follow-up PR.

I needed to pin Node to 16. With newer versions the build was failing due to a change in Node's crypto API. I assume upgrading dependencies will fix that. But let's keep that one for a follow-up PR as well.